### PR TITLE
Fixing nano_postproc.py so modules are ran in order, and sequences are accepted

### DIFF
--- a/scripts/nano_postproc.py
+++ b/scripts/nano_postproc.py
@@ -40,11 +40,15 @@ if __name__ == "__main__":
         import_module(mod)
         obj = sys.modules[mod]
         selnames = names.split(",")
-        for name in dir(obj):
-            if name[0] == "_": continue
-            if name in selnames:
+        mods = dir(obj)
+        for name in selnames:
+            if name in mods:
                 print "Loading %s from %s " % (name, mod)
-                modules.append(getattr(obj,name)())
+                if type(getattr(obj,name)) == list:
+                    for mod in getattr(obj,name):
+                        modules.append( mod())
+                else:
+                    modules.append(getattr(obj,name)())
     if options.noOut:
         if len(modules) == 0: 
             raise RuntimeError("Running with --noout and no modules does nothing!")


### PR DESCRIPTION
Otherwise calling the postprocessor with `-I module.path mod1,mod2,mod3` may end up running the three modules in a different order depending on how they are in the python file.

@sscruz @peruzzim